### PR TITLE
[refactor]: JWT 토큰 생성 및 권한 처리 로직 개선

### DIFF
--- a/src/main/java/com/sparklenote/roll/service/RollService.java
+++ b/src/main/java/com/sparklenote/roll/service/RollService.java
@@ -128,6 +128,7 @@ public class RollService {
         // JWT 토큰 생성
         String accessToken = jwtUtil.createAccessToken(
                 student.getId().toString(),
+                student.getName(),
                 Role.STUDENT, // 학생의 역할을 지정
                 accessTokenExpiration
         );

--- a/src/main/java/com/sparklenote/user/handler/CustomSuccessHandler.java
+++ b/src/main/java/com/sparklenote/user/handler/CustomSuccessHandler.java
@@ -33,8 +33,9 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
         String username = customUserDetails.getUsername();
+        String name = customUserDetails.getName();
 
-        String accessToken = jwtUtil.createAccessToken(username, Role.TEACHER, accessTokenExpiration);
+        String accessToken = jwtUtil.createAccessToken(username, name, Role.TEACHER, accessTokenExpiration);
         String refreshToken = jwtUtil.createRefreshToken(username, refreshTokenExpiration);
 
         // 프론트엔드의 콜백 페이지로 리다이렉트, 프래그먼트에 토큰을 추가

--- a/src/main/java/com/sparklenote/user/jwt/JWTFilter.java
+++ b/src/main/java/com/sparklenote/user/jwt/JWTFilter.java
@@ -50,14 +50,18 @@ public class JWTFilter extends OncePerRequestFilter {
         // 토큰에서 정보 획득
         String username = jwtUtil.getUsername(token);
         String roleName = jwtUtil.getRole(token);
+        String name = jwtUtil.getName(token);
         Role role = Role.valueOf(roleName);
 
         // 역할에 따라 다른 인증 객체 생성
         Authentication authToken;
         if (role == Role.TEACHER) {  // 선생님인 경우
-            UserResponseDTO userResponseDTO = new UserResponseDTO();
-            userResponseDTO.setUsername(username);
-            userResponseDTO.setRole(role);
+
+            UserResponseDTO userResponseDTO = UserResponseDTO.builder()
+                    .username(username)
+                    .name(name)  // name 설정 확인
+                    .role(role)
+                    .build();
 
             CustomOAuth2User customOAuth2User = new CustomOAuth2User(userResponseDTO);
             authToken = new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/sparklenote/user/jwt/JWTUtil.java
+++ b/src/main/java/com/sparklenote/user/jwt/JWTUtil.java
@@ -25,10 +25,11 @@ public class JWTUtil {
         secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), SignatureAlgorithm.HS256.getJcaName());
     }
 
-    public String createAccessToken(String username, Role role, Long expiredMs) {
+    public String createAccessToken(String username,String name, Role role, Long expiredMs) {
         return Jwts.builder()
                 .claim("username", username)
                 .claim("role", role.name())
+                .claim("name",name)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
@@ -53,6 +54,11 @@ public class JWTUtil {
 
         return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
     }
+    public String getName(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("name", String.class);
+    }
+
 
     public Boolean isExpired(String token) {
         try {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR과 관련된 이슈 번호를 적고, 해당 이슈를 닫으세요. 예: closes #이슈번호

## #️⃣ 작업 내용

### 변경 전
- JWT 토큰에서 username 추출 이후 사용자 name 정보 필요 시 매번 DB 조회 수행
- username으로 User 엔티티를 조회하여 name 값을 가져오는 방식

- Roll 생성 시 페이지자 reload되고, /user/info api를 부를 때마다 db조회를 하기 떄문에 리팩토링 해봤습니다!

### 변경 후
- JWT 토큰 생성 시 사용자 **name 정보를 함께 포함**
- Security ContextHolder에 필요한 사용자 정보를 미리 저장
- 사용자 정보 필요 시 ContextHolder에서 바로 조회하여 사용

### 개선 효과
- 불필요한 DB 조회 제거로 API 응답 속도 개선
- 토큰 내 필요 정보 포함으로 효율적인 인증 처리
- DB 부하 감소

## #️⃣ 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요. 예: 모든 테스트 통과 여부, 새로 작성한 테스트 케이스 등

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 필요한 경우, 문서를 작성하거나 수정했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 관련된 스크린샷이 있다면 여기에 첨부해주세요.

## #️⃣ 리뷰 요구사항 (선택)

다른 부분에서도 좀 더 리팩토링 할 수 있는 지 확인 부탁드려요!

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
