### PR TITLE
Refactor 동일 학생 정보(이름/비번)도 반별로 다른 학생으로 생성되도록 수정

### DIFF
--- a/src/main/java/com/sparklenote/domain/repository/StudentRepository.java
+++ b/src/main/java/com/sparklenote/domain/repository/StudentRepository.java
@@ -8,6 +8,6 @@ import java.util.Optional;
 public interface StudentRepository extends JpaRepository<Student, Long> {
     
     // 클래스 코드, 이름, 핀번호로 학생을 찾는 메소드
-    Optional<Student> findByNameAndPinNumber(String name, int pinNumber);
+    Optional<Student> findByNameAndPinNumberAndRollId(String name, int pinNumber,Long id);
     Optional<Student> findByName(String username);
 }

--- a/src/main/java/com/sparklenote/roll/service/RollService.java
+++ b/src/main/java/com/sparklenote/roll/service/RollService.java
@@ -110,13 +110,17 @@ public class RollService {
             throw new RollException(INVALID_CLASS_CODE);
         }
 
-        // 학생 조회 또는 등록
-        Optional<Student> optionalStudent = studentRepository.findByNameAndPinNumber(
+        Optional<Student> optionalStudent = studentRepository.findByNameAndPinNumberAndRollId(
                 joinRequestDto.getName(),
-                joinRequestDto.getPinNumber()
+                joinRequestDto.getPinNumber(),
+                roll.getId()
         );
 
-        Student student = optionalStudent.orElseGet(() -> studentRepository.save(joinRequestDto.toStudent(roll)));
+        Student student = optionalStudent.orElseGet(() -> {
+            // 없으면 새로운 학생으로 등록
+            Student newStudent = joinRequestDto.toStudent(roll);
+            return studentRepository.save(newStudent);
+        });
 
         // JWT 토큰 생성
         String accessToken = jwtUtil.createAccessToken(

--- a/src/test/java/com/sparklenote/roll/service/RollServiceTest.java
+++ b/src/test/java/com/sparklenote/roll/service/RollServiceTest.java
@@ -380,7 +380,7 @@ public class RollServiceTest {
         List<PaperResponseDTO> papers = List.of(new PaperResponseDTO());
 
         given(rollRepository.findByUrl(url)).willReturn(Optional.of(roll));
-        given(studentRepository.findByNameAndPinNumber("홍길동", 1010)).willReturn(Optional.of(student));
+        given(studentRepository.findByNameAndPinNumberAndRollId("홍길동", 1010, 1L)).willReturn(Optional.of(student));
         given(studentRepository.save(any(Student.class))).willReturn(student);
         given(paperService.getPapers(roll.getId())).willReturn(papers);
 
@@ -456,7 +456,7 @@ public class RollServiceTest {
         List<PaperResponseDTO> papers = List.of(new PaperResponseDTO());
 
         given(rollRepository.findByUrl(url)).willReturn(Optional.of(roll));
-        given(studentRepository.findByNameAndPinNumber("홍길동", 1010)).willReturn(Optional.empty());
+        given(studentRepository.findByNameAndPinNumberAndRollId("홍길동", 1010, 1L)).willReturn(Optional.empty());
         given(studentRepository.save(any(Student.class))).willReturn(student);
         given(paperService.getPapers(roll.getId())).willReturn(papers);
 
@@ -493,7 +493,7 @@ public class RollServiceTest {
                 .build();
 
         given(rollRepository.findByUrl(url)).willReturn(Optional.of(roll));
-        given(studentRepository.findByNameAndPinNumber(student.getName(), 1234)).willReturn(Optional.of(student));
+        given(studentRepository.findByNameAndPinNumberAndRollId(student.getName(), 1234, 1L)).willReturn(Optional.of(student));
         given(paperService.getPapers(roll.getId())).willReturn(Collections.emptyList());
 
         //WHEN


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 이 PR과 관련된 이슈 번호를 적고, 해당 이슈를 닫으세요. 예: closes #이슈번호

## #️⃣ 작업 내용

- 동일한 이름과 비밀번호를 가진 학생도 다른 반에서는 새로운 학생으로 생성되도록 수정
- Student 테이블의 unique constraint를 (name, pin_number, roll_id)로 변경
- 학생 조회 로직을 findByNameAndPinNumberAndRollId로 수정하여 반별 독립적인 계정 관리 가능하도록 개선


## #️⃣ 테스트 결과

- 1반에 김현수/1234로 가입 → 정상 가입 확인
- 2반에 동일한 김현수/1234로 가입 → 새로운 학생으로 생성 확인
- 각 반에서 작성 시 해당 반의 roll_id로 정상 작성되는지 확인


## #️⃣ 변경 사항 체크리스트

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [ ] 코드 컨벤션에 따라 코드를 작성했나요?
- [ ] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)
<img width="706" alt="스크린샷 2024-11-16 오후 8 24 21" src="https://github.com/user-attachments/assets/8dfbb77b-ea05-4446-a8b8-c9d1b8579754">


## #️⃣ 리뷰 요구사항 (선택)

- 동일한 이름/비번으로 여러 반에 가입하는 시나리오에서 문제없이 작동하는지 확인 부탁드립니다

## 📎 참고 자료 (선택)

> 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요.
