### PR TITLE
Refactor/roll 학생 이름 공백 제거

### DIFF
--- a/src/main/java/com/sparklenote/roll/dto/request/RollJoinRequestDto.java
+++ b/src/main/java/com/sparklenote/roll/dto/request/RollJoinRequestDto.java
@@ -17,7 +17,7 @@ import org.hibernate.validator.constraints.Range;
 public class RollJoinRequestDto {
 
     @NotBlank(message = "이름은 필수입니다.")
-    @Pattern(regexp = "^[가-힣a-zA-Z\\s]*$", message = "이름은 한글과 영문만 허용됩니다.")
+    @Pattern(regexp = "^[가-힣a-zA-Z]*$", message = "이름은 한글과 영문만 허용됩니다.")
     @Size(min = 1, max = 5, message = "이름은 1자 이상 5자 이하여야 합니다.")
     private String name;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## #️⃣ 작업 내용

> RollJoinRequestDto @Pattern 정규식 변경
> 기존: "^[가-힣a-zA-Z\\s]*$" (한글, 영문, 그리고 공백(\\s)을 허용)
> 변경: "^[가-힣a-zA-Z]*$" (공백(\\s)을 제거하여 한글과 영문만 허용)

## #️⃣ 테스트 결과

## #️⃣ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 필요한 경우, 문서를 작성하거나 수정했나요?
- [x] 코드 컨벤션에 따라 코드를 작성했나요?
- [x] 본 PR에서 발생할 수 있는 모든 의존성 문제가 해결되었나요?

## #️⃣ 스크린샷 (선택)

> 
<img width="596" alt="image" src="https://github.com/user-attachments/assets/9f1c0b9c-a982-4712-9893-445c05a916ba">

변경 후 테스트 진행했는데 정상적으로 처리 되었습니다.

